### PR TITLE
update express to 2.5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   , "version": "0.0.1"
   , "private": true
   , "dependencies": {
-      "express": "2.4.6"
+      "express": "2.5.8"
     , "jade": ">= 0.0.1"
     , "socket.io": "0.8.5"
     , "findit": "0.1.1"


### PR DESCRIPTION
`express@2.4.6` requires `"node":">= 0.4.1 < 0.5.0"` - so this will make it work on `"node": ">= 0.4.1 < 0.7.0"`
